### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: java
+jdk:
+- oraclejdk7
+install: true
+script: ./buildViaTravis.sh
+after_success:
+- ./gradlew jacoco coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,22 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.+'
     }
 }
 
+plugins {
+    id 'maven-publish'
+    id 'jacoco'
+    id 'com.github.kt3k.coveralls' version '2.6.3'
+    id 'nebula.nebula-release' version '4.0.1'
+    id 'com.jfrog.bintray' version '1.6'
+    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'nebula.optional-base' version '3.1.0'
+}
+
 apply plugin: 'kotlin'
-apply plugin: 'nebula.optional-base'
+
+group = 'org.springframework'
 
 repositories {
     mavenCentral()
@@ -24,4 +34,70 @@ dependencies {
 
     testCompile 'junit:junit:4.+'
     testCompile 'org.assertj:assertj-core:3.+'
+}
+
+bintray {
+    user = 'sdeleuze'
+    key = System.getenv('BINTRAY_KEY')
+    dryRun = false
+    publish = true
+    publications = ['Bintray']
+
+    pkg {
+        repo = 'maven'
+        name = 'spring-kotlin'
+        vcsUrl = 'git@github.com:sdeleuze/spring-kotlin.git'
+        websiteUrl = 'https://github.com/sdeleuze/spring-kotlin'
+        issueTrackerUrl = 'https://github.com/sdeleuze/spring-kotlin/issues'
+        licenses = ['Apache-2.0']
+        labels = ['spring', 'kotlin']
+        publicDownloadNumbers = true
+        version {
+            name = project.version
+            vcsTag = project.version
+        }
+    }
+}
+
+publishing {
+    publications {
+        Bintray(MavenPublication) {
+            pom.withXml {
+                def node = asNode()
+                node.children().last() + {
+                    resolveStrategy = Closure.DELEGATE_FIRST
+
+                    name 'spring-kotlin'
+                    description 'power assertions for java'
+                    url 'https://github.com/sdeleuze/spring-kotlin'
+                    scm {
+                        url 'https://github.com/sdeleuze/spring-kotlin.git'
+                        connection 'scm:git@github.com:sdeleuze/spring-kotlin.git'
+                        developerConnection 'git@github.com:sdeleuze/spring-kotlin.git'
+                        tag 'HEAD'
+                    }
+                    licenses {
+                        license {
+                            name 'The Apache Software License, Version 2.0'
+                            url 'http://www.apache.org/license/LICENSE-2.0.txt'
+                            distribution 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id 'sdeleuze'
+                            name 'Sébastien Deleuze'
+                            email 'sdeleuze@pivotal.com'
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+    }
 }

--- a/buildViaTravis.sh
+++ b/buildViaTravis.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script will build the project.
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo -e "Build Pull Request #$TRAVIS_PULL_REQUEST => Branch [$TRAVIS_BRANCH]"
+  ./gradlew test
+elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" == "" ]; then
+  echo -e 'Build Branch with Snapshot => Branch ['$TRAVIS_BRANCH']'
+  ./gradlew -Prelease.travisci=true test
+elif [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_TAG" != "" ]; then
+  echo -e 'Build Branch for Release => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']'
+  case "$TRAVIS_TAG" in
+  *-rc\.*)
+    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true candidate
+    ;;
+  *)
+    ./gradlew -Prelease.travisci=true -Prelease.useLastTag=true final
+    ;;
+  esac
+else
+  echo -e 'WARN: Should not be here => Branch ['$TRAVIS_BRANCH']  Tag ['$TRAVIS_TAG']  Pull Request ['$TRAVIS_PULL_REQUEST']'
+  ./gradlew build
+fi


### PR DESCRIPTION
@sdeleuze This contains everything necessary to get an artifact out to Bintray/JCenter. I suppose we should put this in your Bintray repo. After merging, you'll need to do the following from the project root:

Not sure what the `group` should be, so I made it 'org.springframework' temporarily. Change it to whatever you think it should be.

```
gem install travis
cd my_project
travis encrypt BINTRAY_KEY=super_secret --add env.matrix
```

Once this is committed, you can cause a release to be published to Bintray simply by pushing a tag (e.g. v0.1.0) or performing a release on Github. Both have the same effect.

Once the first release lands in Bintray, click the "Add to JCenter" link on the spring-kotlin package page in Bintray, and we will be good to go.